### PR TITLE
Clean Google Map hover tooltip

### DIFF
--- a/src/GoogleMap.js
+++ b/src/GoogleMap.js
@@ -11,24 +11,15 @@ function GoogleMap ({ province, newData }) {
         "Deaths",
         "Recovered"
     ];
+
   const [loading, setLoading] = useState(true);
     useEffect(() => {
 
         setLoading(false)
-        // if (province) {
-        //   import(`echarts/map/json/province/${province.pinyin}.json`).then(map => {
-        //     echarts.registerMap(province.pinyin, map.default)
-        //     setLoading(false)
-        //   })
-        // } else {
-        //   import(`echarts/map/json/world.json`).then(map => {
-        //     echarts.registerMap('world', map.default)
-        //     setLoading(false)
-        //   })
-        // }
 
     }, [province]);
-    const [ myData, setMyData] = useState(null);
+  
+  const [ myData, setMyData] = useState(null);
     useEffect(() => {
 
         let translate = {
@@ -44,110 +35,23 @@ function GoogleMap ({ province, newData }) {
         let temp = [["state","confirmed"]]
         for(let i = 0; i < newData.length; i++)
         {
-            temp.push([translate[newData[i][0]],parseInt(newData[i][1])])
+            // Add each data row.
+            // v: Tooltip text, f: ISO region code
+            temp.push([{v:translate[newData[i][0]], f:newData[i][0]}, parseInt(newData[i][1])])
         }
 
         setMyData(temp)
 
     }, [province]);
 
-    // const getOption = () => {
-  //   return {
-  //     visualMap: {
-  //       show: true,
-  //       type: 'piecewise',
-  //       min: 0,
-  //       max: 2000,
-  //       align: 'right',
-  //       top: province ? 0 : '40%',
-  //       right: 0,
-  //       left: province ? 0 : 'auto',
-  //       inRange: {
-  //         color: [
-  //           '#ffc0b1',
-  //           '#ff8c71',
-  //           '#ef1717',
-  //           '#9c0505'
-  //         ]
-  //       },
-  //       pieces: [
-  //         {min: 1000},
-  //         {min: 500, max: 999},
-  //         {min: 100, max: 499},
-  //         {min: 10, max: 99},
-  //         {min: 1, max: 9},
-  //       ],
-  //       padding: 5,
-  //       // "inverse": false,
-  //       // "splitNumber": 5,
-  //       orient: province ? 'horizontal' : 'vertical',
-  //       showLabel: province ? false : true,
-  //       text: ['High', 'low'],
-  //       itemWidth: 10,
-  //       itemHeight: 10,
-  //       textStyle: {
-  //         fontSize: 10
-  //       }
-  //       // "borderWidth": 0
-  //     },
-  //     series: [{
-  //       left: 'center',
-  //       // top: '15%',
-  //       // bottom: '10%',
-  //       type: 'map',
-  //       name: 'Confirmed',
-  //       silent: province ? true : false,
-  //       label: {
-  //         show: true,
-  //         position: 'inside',
-  //         // margin: 8,
-  //         fontSize: 6
-  //       },
-  //       mapType: province ? province.pinyin : 'world',
-  //       data,
-  //       zoom: 1.2,
-  //       roam: false,
-  //       showLegendSymbol: false,
-  //       emphasis: {},
-  //       rippleEffect: {
-  //         show: true,
-  //         brushType: 'stroke',
-  //         scale: 2.5,
-  //         period: 4
-  //       }
-  //     }]
-  //   }
-  // }
-
-  // return (
-  //   loading ? <div className="loading">Loading...</div> :
-  //   <ReactEcharts
-  //     echarts={echarts}
-  //     option={getOption()}
-  //     lazyUpdate={true}
-  //     onEvents={{
-  //       click (e) {
-  //         onClick(e.name)
-  //       }
-  //     }}
-  //   />
-  // )
-
-
-
-    // const csv = require('fast-csv')
-    // const fs = require('fs')
-    //
-
   const getOption = () => {
       return {
-          region: 'AU', // Africa
+          region: 'AU', // ISO 3166-1 alpha-2 code for Australia
           colorAxis: { colors: [
                     '#ffefef',
                   '#ffc0b1',
                   '#ff8c71',
-                  '#ef1717',
-                  // '#9c0505'
+                  '#ef1717'
               ] },
           backgroundColor: 'white',
           datalessRegionColor: 'rgb(216,221,224)',
@@ -156,7 +60,6 @@ function GoogleMap ({ province, newData }) {
       }
   };
 
-
   return (
     loading ? <div className="loading">Loading...</div> :
         <Chart
@@ -164,8 +67,6 @@ function GoogleMap ({ province, newData }) {
             left="auto"
             align="right"
             top="40%"
-            // width={'500px'}
-            // height={'300px'}
             chartType="GeoChart"
             data={myData}
             options={getOption()}

--- a/src/GoogleMap.js
+++ b/src/GoogleMap.js
@@ -32,7 +32,7 @@ function GoogleMap ({ province, newData }) {
             "SA":"AU-SA",
             "TAS":"AU-TAS",
         }
-        let temp = [["state","confirmed"]]
+        let temp = [["state","Confirmed"]]
         for(let i = 0; i < newData.length; i++)
         {
             // Add each data row.

--- a/src/GoogleMap.js
+++ b/src/GoogleMap.js
@@ -49,9 +49,10 @@ function GoogleMap ({ province, newData }) {
           region: 'AU', // ISO 3166-1 alpha-2 code for Australia
           colorAxis: { colors: [
                     '#ffefef',
-                  '#ffc0b1',
-                  '#ff8c71',
-                  '#ef1717'
+                    '#ffc0b1',
+                    '#ff8c71',
+                    '#ef1717'
+                    // '#9c0505'
               ] },
           backgroundColor: 'white',
           datalessRegionColor: 'rgb(216,221,224)',


### PR DESCRIPTION
Remove the 'AU-' prefix from the Google Map on-hover tooltip.

Key change is L40, rest is file cleanup.

![firefox_3QuWM9pdM5](https://user-images.githubusercontent.com/7892801/77225009-31ffe180-6bbf-11ea-80f1-d9c925a9fa70.png)
