### PR TITLE
Fixed mapdata.json Albert Park Hotel coordinates

### DIFF
--- a/src/data/mapdata.json
+++ b/src/data/mapdata.json
@@ -106,7 +106,7 @@
     "name": "Albert Park Hotel",
     "state": "Victoria",
     "onset of symptoms up to": "21/3/20",
-    "coor": ["-37.825005", " 144.983814"],
+    "coor": ["-37.841153", " 144.955694"],
     "type": "0"
   },
   {


### PR DESCRIPTION
The Albert Park Hotel coordinates are wrong, I updated mapdata.json to show the correct coordinates (-37.841153, 144.955694).