### PR TITLE
Fixed mapdataCon.json Albert Park hotel coordinates

### DIFF
--- a/src/data/mapdataCon.json
+++ b/src/data/mapdataCon.json
@@ -91,7 +91,7 @@
     "name": "Albert Park Hotel",
     "state": "VIC",
     "onset of symptoms up to": "21/3/20",
-    "coor": ["-37.825005", "144.983814"],
+    "coor": ["-37.841153", "144.955694"],
     "type": "0",
     "notes": ""
   },


### PR DESCRIPTION
In my previous pull request I only added the details to the mapdata.json file, now I've added them to mapdataCon.json as well