### PR TITLE
update readme to specify what env key to use for mapbox api access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This site accumulates the information from different resources including:
 
 - Then contact Han to grab an API access token for dev environment
 
-> - `cd` to the root, and create an `env` file by `touch .env`
-> - copy the token to this file
+> - `cd` to the root, and create an `env` file
+>   -  `echo 'REACT_APP_MAP_API=your_api_key' > .env.development.local`
 
 - run `npm start`, then everything should be up.
 


### PR DESCRIPTION
Instructions didn't tell me what which key I had to use for the environment variable, updated it here to be less confusing